### PR TITLE
Added TDM to listen server dropdown ignore list.

### DIFF
--- a/game/ges/client/VGUI/ge_createserver.cpp
+++ b/game/ges/client/VGUI/ge_createserver.cpp
@@ -356,8 +356,8 @@ void CGECreateServer::PopulateControls( void )
 		const char *pFilename = filesystem->FindFirstEx( PYDIR, "MOD", &findHandle );
 		while ( pFilename )
 		{
-			// Add the scenario to the list if not __init__
-			if ( !Q_stristr( pFilename, "__init__") )
+			// Add the scenario to the list if not __init__ or TDM
+			if ( !Q_stristr(pFilename, "__init__") && !Q_stristr(pFilename, "tournamentdm") )
 			{
 				Q_FileBase( pFilename, file, 32 );
 				scenariolist->AddItem( file, new KeyValues(file) );

--- a/game/ges/client/VGUI/ge_loadingscreen.cpp
+++ b/game/ges/client/VGUI/ge_loadingscreen.cpp
@@ -166,7 +166,12 @@ const char *CGELevelLoadingPanel::GetCurrentImage()
 void CGELevelLoadingPanel::DisplayTip( void )
 {
 	const GameplayTip *tip = GetClientModeGENormal()->GetRandomTip();
-	if ( tip )
+
+	if (!Q_strcmp(GetCurrentImage(), GetDefaultImage()))
+	{
+		m_pTipContainer->SetText(""); // No tips on the default loading screen.
+	}
+	else if ( tip )
 	{
 		wchar_t tmp[128];
 		g_pVGuiLocalize->ConstructString( tmp, sizeof(tmp), g_pVGuiLocalize->Find("#GE_TIP_TITLE"), 1, tip->name );

--- a/game/ges/server/ge_player.cpp
+++ b/game/ges/server/ge_player.cpp
@@ -1044,9 +1044,9 @@ void CGEPlayer::InitialSpawn( void )
 
 	HideBloodScreen();
 
-	// Disable npc interp if we are localhost
-	if ( !engine->IsDedicatedServer() && entindex() == 1 )
-		engine->ClientCommand( edict(), "cl_interp_npcs 0" );
+	// Disable npc interp if we are localhost...but this makes them all jerky for the localhost so I'm disabling it for now.
+	//if ( !engine->IsDedicatedServer() && entindex() == 1 )
+	//	engine->ClientCommand( edict(), "cl_interp_npcs 0" );
 }
 
 void CGEPlayer::Spawn()

--- a/game/ges/server/mp/gebot_player.cpp
+++ b/game/ges/server/mp/gebot_player.cpp
@@ -154,6 +154,7 @@ void CGEBotPlayer::Spawn( void )
 	AddFlag( FL_NOTARGET ); // Don't let NPC's "see" us
 	SetMoveType( MOVETYPE_NOCLIP );
 	AddSolidFlags( FSOLID_NOT_SOLID );
+	SetSolid( SOLID_NONE );
 	// Make sure we are virginal
 	RemoveAllAmmo();
 	RemoveAllWeapons();
@@ -489,7 +490,7 @@ void CGEBotPlayer::CreateRagdollEntity()
 void CGEBotPlayer::PreThink( void )
 {
 	BaseClass::PreThink();
-	
+
 	// Move us to where the NPC is for radar (mainly)
 	SetAbsOrigin( m_pNPC->GetAbsOrigin() );
 	SetLocalAngles( m_pNPC->GetLocalAngles() );

--- a/game/ges/server/mp/gemp_player.cpp
+++ b/game/ges/server/mp/gemp_player.cpp
@@ -1393,21 +1393,6 @@ void CGEMPPlayer::Event_Killed( const CTakeDamageInfo &info )
 
 	NotifyOnDeath();
 
-	bool killedByTrigger = (!Q_stricmp("trigger_hurt", info.GetAttacker()->GetClassname()) || !Q_stricmp("trigger_trap", info.GetAttacker()->GetClassname()));
-	CBaseCombatWeapon *pWeapon;
-	
-	// Check if we were killed by a trigger and our active weapon is a token
-	// if so remove it from the world so we don't just drop it
-	if ( killedByTrigger )
-	{
-		pWeapon = GetActiveWeapon();
-		if ( pWeapon && GEMPRules()->GetTokenManager()->IsValidToken(pWeapon->GetClassname()) )
-		{
-			Weapon_Detach( pWeapon );
-			UTIL_Remove( pWeapon );
-		}
-	}
-
 	BaseClass::Event_Killed( info );
 
 	// Call into our anim handler and setup our death animations

--- a/game/ges/shared/ge_weapon.cpp
+++ b/game/ges/shared/ge_weapon.cpp
@@ -585,6 +585,8 @@ void CGEWeapon::SetupGlow( bool state, Color glowColor /*=Color(255,255,255)*/, 
 
 	if ( !GetOwner() || (GetOwner() && !GetOwner()->IsPlayer()) )
 		SetEnableGlow( state );
+
+	UpdateTransmitState();
 }
 
 void CGEWeapon::SetEnableGlow( bool state )
@@ -592,6 +594,13 @@ void CGEWeapon::SetEnableGlow( bool state )
 	m_bEnableGlow = state;
 }
 
+int CGEWeapon::UpdateTransmitState()
+{
+	if (m_bServerGlow)
+		return SetTransmitState(FL_EDICT_ALWAYS);
+	else
+		return BaseClass::UpdateTransmitState();
+}
 #endif
 
 void CGEWeapon::PreOwnerDeath()

--- a/game/ges/shared/ge_weapon.h
+++ b/game/ges/shared/ge_weapon.h
@@ -74,6 +74,7 @@ public:
 #ifdef GAME_DLL
 	virtual void	Spawn();
 	virtual void	UpdateOnRemove();
+	virtual int		UpdateTransmitState();
 
 	virtual float	GetHeldTime() { return gpGlobals->curtime - m_flDeployTime; };
 	virtual bool	CanEquip( CBaseCombatCharacter *pOther ) { return true; };

--- a/game/ges/shared/weapon_mines.cpp
+++ b/game/ges/shared/weapon_mines.cpp
@@ -254,17 +254,17 @@ IMPLEMENT_NETWORKCLASS_ALIASED( WeaponRemoteMine, DT_WeaponRemoteMine )
 BEGIN_NETWORK_TABLE( CWeaponRemoteMine, DT_WeaponRemoteMine )
 #ifdef CLIENT_DLL
 	RecvPropBool( RECVINFO( m_bWatchDeployed ) ),
-	RecvPropInt( RECVINFO(m_iWatchModelIndex) ),
+//	RecvPropInt( RECVINFO(m_iWatchModelIndex) ),
 #else
 	SendPropBool( SENDINFO( m_bWatchDeployed ) ),
-	SendPropModelIndex( SENDINFO(m_iWatchModelIndex) ),
+//	SendPropModelIndex( SENDINFO(m_iWatchModelIndex) ),
 #endif
 END_NETWORK_TABLE()
 
 #ifdef CLIENT_DLL
 BEGIN_PREDICTION_DATA( CWeaponRemoteMine )
 	DEFINE_PRED_FIELD( m_bWatchDeployed, FIELD_BOOLEAN, FTYPEDESC_INSENDTABLE ),
-	DEFINE_PRED_FIELD( m_iWatchModelIndex, FIELD_INTEGER, FTYPEDESC_INSENDTABLE | FTYPEDESC_MODELINDEX ),
+//	DEFINE_PRED_FIELD( m_iWatchModelIndex, FIELD_INTEGER, FTYPEDESC_INSENDTABLE | FTYPEDESC_MODELINDEX ),
 END_PREDICTION_DATA()
 #endif
 
@@ -334,7 +334,7 @@ void CWeaponRemoteMine::Precache( void )
 
 	PrecacheScriptSound( "weapon_mines.WatchBeep" );
 
-	m_iWatchModelIndex = CBaseEntity::PrecacheModel( "models/weapons/mines/w_watch.mdl" );
+//	m_iWatchModelIndex = CBaseEntity::PrecacheModel( "models/weapons/mines/w_watch.mdl" );
 	BaseClass::Precache();
 }
 
@@ -344,7 +344,7 @@ int C_WeaponRemoteMine::GetWorldModelIndex( void )
 	if ( GetOwner() && GetOwner()->IsPlayer() )
 	{
 		if ( m_bWatchDeployed )
-			return m_iWatchModelIndex;
+			return NULL;
 		else
 			return m_iWorldModelIndex;
 	}

--- a/game/ges/shared/weapon_mines.h
+++ b/game/ges/shared/weapon_mines.h
@@ -142,7 +142,7 @@ public:
 	virtual int  GetWorldModelIndex( void );
 #endif
 
-	CNetworkVar( int, m_iWatchModelIndex );
+//	CNetworkVar( int, m_iWatchModelIndex );
 
 private:
 	CWeaponRemoteMine( const CWeaponRemoteMine & );

--- a/game/sdk/server/ai_basenpc.cpp
+++ b/game/sdk/server/ai_basenpc.cpp
@@ -12150,10 +12150,23 @@ bool CAI_BaseNPC::OnObstructionPreSteer( AILocalMoveGoal_t *pMoveGoal,
 	if ( pMoveGoal->directTrace.pObstruction )
 	{
 		CBaseDoor *pDoor = dynamic_cast<CBaseDoor *>( pMoveGoal->directTrace.pObstruction );
+
+#ifdef GE_DLL
+		if (!pDoor)
+		{
+			if (pMoveGoal->directTrace.pObstruction->GetParent())
+				pDoor = dynamic_cast<CBaseDoor *>(pMoveGoal->directTrace.pObstruction->GetParent());
+		}
+#endif
 		if ( pDoor && OnObstructingDoor( pMoveGoal, pDoor, distClear, pResult ) )
 		{
 			return true;
 		}
+
+#ifdef GE_DLL
+		if (pMoveGoal->directTrace.pObstruction->IsPlayer() || pMoveGoal->directTrace.pObstruction->IsNPC())
+			return true;
+#endif
 	}
 
 	return false;

--- a/game/sdk/server/ai_hull.cpp
+++ b/game/sdk/server/ai_hull.cpp
@@ -38,7 +38,7 @@ ai_hull_t  Large_Centered_Hull	(bits_LARGE_CENTERED_HULL,	"LARGE_CENTERED_HULL",
 ai_hull_t  Medium_Tall_Hull		(bits_MEDIUM_TALL_HULL,		"MEDIUM_TALL_HULL",		Vector(-18,-18,   0),	Vector(18, 18, 100),	Vector(-12,-12, 0),	    Vector(12, 12, 100) );
 #else
 #ifdef GE_DLL
-ai_hull_t  Human_Hull			(bits_HUMAN_HULL,			"HUMAN_HULL",			Vector(-12,-12,   0),	Vector(12, 12, 72),		Vector(-12,-12,   0),		Vector( 12,  12, 72) );
+ai_hull_t  Human_Hull			(bits_HUMAN_HULL,			"HUMAN_HULL",			Vector(-12.5,-12.5,   0),	Vector(12.5, 12.5, 72),		Vector(-12.5,-12.5,   0),		Vector( 12.5,  12.5, 72) );
 #else
 ai_hull_t  Human_Hull			(bits_HUMAN_HULL,			"HUMAN_HULL",			Vector(-13,-13,   0),	Vector(13, 13, 72),		Vector(-8,-8,   0),		Vector( 8,  8, 72) );
 #endif

--- a/game/sdk/server/player_lagcompensation.cpp
+++ b/game/sdk/server/player_lagcompensation.cpp
@@ -16,6 +16,7 @@
 //GE_DLL
 #include "ai_basenpc.h"
 #include "ge_gamerules.h"
+#include "gebot_player.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -1269,11 +1270,29 @@ void CLagCompensationManager::FinishLagCompensation( CBasePlayer *player )
 		}
 
 #ifdef GE_DLL
-		// Modify Collision Bounds back to normal
-		if ( pPlayer->GetFlags() & FL_DUCKING )
-			pPlayer->SetCollisionBounds( VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX );
+		// Bot players need their NPC's hitboxes adjusted, not their player's.
+		CGEBotPlayer *pBotPlayer = ToGEBotPlayer(pPlayer);
+
+		if (pBotPlayer)
+		{
+			CNPC_GEBase *pBotNPC = pBotPlayer->GetNPC();
+			// Modify Collision Bounds back to normal
+			if (pBotNPC)
+			{
+				if (pBotNPC->GetFlags() & FL_DUCKING)
+					pBotNPC->SetCollisionBounds(VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX);
+				else
+					pBotNPC->SetCollisionBounds(VEC_HULL_MIN, VEC_HULL_MAX);
+			}
+		}
 		else
-			pPlayer->SetCollisionBounds( VEC_HULL_MIN, VEC_HULL_MAX );
+		{
+			// Modify Collision Bounds back to normal
+			if (pPlayer->GetFlags() & FL_DUCKING)
+				pPlayer->SetCollisionBounds(VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX);
+			else
+				pPlayer->SetCollisionBounds(VEC_HULL_MIN, VEC_HULL_MAX);
+		}
 #endif
 
 		LagRecord *restore = &m_RestoreData[ pl_index ];

--- a/public/const.h
+++ b/public/const.h
@@ -365,11 +365,11 @@ enum Collision_Group_t
 	COLLISION_GROUP_NPC_SCRIPTED,	// USed for NPCs in scripts that should not collide with each other
 
 #ifdef GE_DLL
-	COLLISION_GROUP_MINE,
+	COLLISION_GROUP_MINE, // If you add anything to this list, be sure to do it at the end otherwise you'll mess up maps that use func_ge_brush.
 	COLLISION_GROUP_GRENADE,
 	COLLISION_GROUP_TKNIFE,
 	COLLISION_GROUP_DROPPEDWEAPON,
-	COLLISION_GROUP_BLOCKWEAPONS,
+	COLLISION_GROUP_BLOCKWEAPONS, // This one -really- needs to stay in this exact posistion, the other ones not as much.
 	COLLISION_GROUP_CAPAREA,
 	COLLISION_GROUP_MI6,
 	COLLISION_GROUP_JANUS,


### PR DESCRIPTION
Tips no longer display on default loading screen
func_ge_brush can now use vphysics for remove function
disabled npc interp for now
kill triggers no longer remove weapons from killed players as this function has been replaced by func_ge_brush
token weapons are now set to always transmit their state, so they don't desynch on client/server.
remote mines no longer display detonator in world view until we get a new one
bots wait for ge_doors to open before moving through them
bots use proper hull size now
bots no longer go huge when getting shot at (The collision model no longer expands due to lag compensation checks and then fails to go back)
